### PR TITLE
Potential fix for code scanning alert no. 25: Uncontrolled command line

### DIFF
--- a/src/VulnerableApp/src/VulnerableApp.java
+++ b/src/VulnerableApp/src/VulnerableApp.java
@@ -27,8 +27,21 @@ public class VulnerableApp extends HttpServlet {
         // Vulnerability 2: Command Injection
         try {
             String data = request.getParameter("data");
-            // Unsafe command execution
-            Runtime.getRuntime().exec("echo " + data);
+            // Validate the input to allow only alphanumeric characters and spaces
+            if (data != null && data.matches("[a-zA-Z0-9 ]*")) {
+                // Use ProcessBuilder for safer command execution
+                ProcessBuilder pb = new ProcessBuilder("echo", data);
+                pb.redirectErrorStream(true);
+                Process process = pb.start();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                String line;
+                PrintWriter pw = response.getWriter();
+                while ((line = reader.readLine()) != null) {
+                    pw.println(line);
+                }
+            } else {
+                response.getWriter().println("Invalid input.");
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Potential fix for [https://github.com/gregkn/bsidessf-hands-on-devsecops-2025/security/code-scanning/25](https://github.com/gregkn/bsidessf-hands-on-devsecops-2025/security/code-scanning/25)

To fix the issue, we need to ensure that user input is not directly passed to `Runtime.getRuntime().exec`. Instead, we should validate and sanitize the input or use safer alternatives. In this case, we can use a hardcoded command and pass the user input as an argument to the command in a safe manner. The `ProcessBuilder` class is a safer alternative to `Runtime.exec` because it allows us to separate the command and its arguments, preventing command injection.

Steps to fix:
1. Replace the use of `Runtime.getRuntime().exec` with `ProcessBuilder`.
2. Validate the `data` parameter to ensure it contains only safe characters (e.g., alphanumeric characters and spaces).
3. Pass the validated `data` as an argument to the `echo` command using `ProcessBuilder`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
